### PR TITLE
Add simple weather service

### DIFF
--- a/pages/api/weather.js
+++ b/pages/api/weather.js
@@ -1,0 +1,25 @@
+import fetch from 'node-fetch';
+
+export default async function handler(req, res) {
+  const { location } = req.query;
+  if (!location) {
+    return res.status(400).json({ error: 'Missing location' });
+  }
+  try {
+    const resp = await fetch(`https://wttr.in/${encodeURIComponent(location)}?format=j1`);
+    if (!resp.ok) {
+      return res.status(500).json({ error: 'Failed to fetch weather' });
+    }
+    const data = await resp.json();
+    const current = data.current_condition && data.current_condition[0];
+    if (!current) {
+      return res.status(404).json({ error: 'No weather data available' });
+    }
+    res.status(200).json({
+      tempC: current.temp_C,
+      description: current.weatherDesc[0].value,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,13 @@
+import Link from 'next/link';
+
 export default function Home() {
   return (
     <main>
       <h1>Hello, Next.js Template!</h1>
       <p>This is a simple page for Next.js.</p>
+      <p>
+        <Link href="/weather">Go to Weather Service</Link>
+      </p>
     </main>
   );
 }
-

--- a/pages/weather.js
+++ b/pages/weather.js
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import Link from 'next/link';
+
+export default function WeatherPage() {
+  const [location, setLocation] = useState('');
+  const [weather, setWeather] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchWeather = async () => {
+    if (!location) return;
+    setLoading(true);
+    setError(null);
+    setWeather(null);
+    try {
+      const res = await fetch(`/api/weather?location=${encodeURIComponent(location)}`);
+      if (!res.ok) {
+        throw new Error('Failed to fetch weather');
+      }
+      const data = await res.json();
+      if (data.error) {
+        setError(data.error);
+      } else {
+        setWeather(data);
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main>
+      <h1>Weather Service</h1>
+      <Link href="/">Home</Link>
+      <div>
+        <input
+          type="text"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          placeholder="Enter location"
+        />
+        <button onClick={fetchWeather} disabled={loading}>Get Weather</button>
+      </div>
+      {loading && <p>Loading...</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {weather && (
+        <div>
+          <h2>{location}</h2>
+          <p>{weather.description}</p>
+          <p>{weather.tempC}&deg;C</p>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,17 @@
-1st
+# Next.js Weather Service
+
+This simple Next.js project now includes a weather page that retrieves the current weather for a location.
+Weather data is fetched from [wttr.in](https://wttr.in/) via a serverless API route.
+
+## Development
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+Then navigate to `http://localhost:3000/weather` to try the weather service.
+
+The page sends requests to `/api/weather?location=YOUR_LOCATION` which acts as a
+proxy to the external service.


### PR DESCRIPTION
## Summary
- add Weather page to fetch weather from wttr.in
- link to Weather page from the home page
- update README with instructions
- add serverless API route to proxy wttr.in requests

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b682449708329a36c8d2bef4c6aae