### PR TITLE
Add pollen forecast page

### DIFF
--- a/pages/pollen.js
+++ b/pages/pollen.js
@@ -1,0 +1,30 @@
+export default function PollenForecast() {
+  const today = new Date();
+  const forecast = [];
+  for (let i = 0; i < 7; i++) {
+    const date = new Date(today);
+    date.setDate(today.getDate() + i);
+    const month = date.getMonth() + 1;
+    let level;
+    if (month === 3 || month === 4) {
+      level = '高い';
+    } else if (month === 2 || month === 5) {
+      level = '中程度';
+    } else {
+      level = '低い';
+    }
+    forecast.push({ date: date.toISOString().split('T')[0], level });
+  }
+
+  return (
+    <main>
+      <h1>花粉予測</h1>
+      <p>次の7日間の簡易花粉レベル予測です。</p>
+      <ul>
+        {forecast.map((item) => (
+          <li key={item.date}>{item.date}: {item.level}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,11 @@
-1st
+# Next.js Template
+
+This project contains a simple Next.js setup with a couple of example pages.
+
+## Available Pages
+
+- `/` - Home page
+- `/template` - Example template page
+- `/pollen` - Displays a simple 7-day pollen forecast
+
+Run the development server with `npm run dev`.


### PR DESCRIPTION
## Summary
- add a pollen forecast page with simple logic
- document the new page in the readme

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850d32f16a0832985453fc69a4bffe2